### PR TITLE
상품 히스토리 테이블에 상품 변경 이력을 관리한다.

### DIFF
--- a/product-api/http/product.http
+++ b/product-api/http/product.http
@@ -10,25 +10,27 @@ Content-Type: application/json
 }
 
 ### 상품 조회
-GET http://localhost:8080/v1/products/46
-Content-Type: application/json
+GET http://localhost:8080/v1/products/72
 
 ### 상품 수정
-PUT http://localhost:8080/v1/products/46
+PUT http://localhost:8080/v1/products/72
 Content-Type: application/json
 
 {
   "name": "foo-bar",
   "price": 10000,
   "quantity": 10,
-  "status": "STOP",
+  "status": "SOLD_OUT",
   "memberNumber": "0000"
 }
 
 ### 상품 삭제
-DELETE http://localhost:8080/v1/products/46
+DELETE http://localhost:8080/v1/products/72
 Content-Type: application/json
 
 {
   "memberNumber": "0000"
 }
+
+### 상품 히스토리 조회
+GET http://localhost:8080/v1/products/72/histories

--- a/product-api/src/docs/asciidoc/index.adoc
+++ b/product-api/src/docs/asciidoc/index.adoc
@@ -1,4 +1,4 @@
-= API 문서
+= 상품 어드민 API 문서
 :doctype: book
 :icons: font
 :source-highlighter: highlightjs
@@ -55,3 +55,15 @@ include::{snippets}/product/delete/request-fields.adoc[]
 === 응답
 
 include::{snippets}/product/delete/http-response.adoc[]
+
+== 상품 히스토리 조회
+
+=== 요청
+
+include::{snippets}/product/product-histories/http-request.adoc[]
+include::{snippets}/product/product-histories/path-parameters.adoc[]
+include::{snippets}/product/product-histories/request-fields.adoc[]
+
+=== 응답
+
+include::{snippets}/product/product-histories/http-response.adoc[]

--- a/product-api/src/main/kotlin/com/example/productapi/product/api/controller/ProductController.kt
+++ b/product-api/src/main/kotlin/com/example/productapi/product/api/controller/ProductController.kt
@@ -1,4 +1,4 @@
-package com.example.productapi.product.api
+package com.example.productapi.product.api.controller
 
 import com.example.productapi.product.api.request.ProductCreateRequest
 import com.example.productapi.product.api.request.ProductEditRequest

--- a/product-api/src/main/kotlin/com/example/productapi/product/api/controller/ProductHistoryController.kt
+++ b/product-api/src/main/kotlin/com/example/productapi/product/api/controller/ProductHistoryController.kt
@@ -1,10 +1,23 @@
 package com.example.productapi.product.api.controller
 
+import com.example.productapi.product.api.response.ProductHistoryResponse
+import com.example.productdomain.product.application.ProductHistoryQueryService
 import lombok.extern.slf4j.Slf4j
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RestController
 
 @Slf4j
 @RestController
 class ProductHistoryController(
+    val productHistoryQueryService: ProductHistoryQueryService
 ) {
+
+    @GetMapping("/v1/products/{productId}/histories")
+    fun getProductHistories(@PathVariable productId: Long): List<ProductHistoryResponse> {
+
+        return productHistoryQueryService.getProductHistories(productId)
+            .map { ProductHistoryResponse.from(it) }
+            .toList()
+    }
 }

--- a/product-api/src/main/kotlin/com/example/productapi/product/api/controller/ProductHistoryController.kt
+++ b/product-api/src/main/kotlin/com/example/productapi/product/api/controller/ProductHistoryController.kt
@@ -1,0 +1,10 @@
+package com.example.productapi.product.api.controller
+
+import lombok.extern.slf4j.Slf4j
+import org.springframework.web.bind.annotation.RestController
+
+@Slf4j
+@RestController
+class ProductHistoryController(
+) {
+}

--- a/product-api/src/main/kotlin/com/example/productapi/product/api/response/ProductHistoryResponse.kt
+++ b/product-api/src/main/kotlin/com/example/productapi/product/api/response/ProductHistoryResponse.kt
@@ -1,0 +1,27 @@
+package com.example.productapi.product.api.response
+
+import com.example.productdomain.product.domain.ProductHistory
+import com.example.productdomain.product.domain.ProductStatus
+import java.time.LocalDateTime
+
+data class ProductHistoryResponse(
+
+    val createdAt: LocalDateTime,
+    val createdBy: String,
+    val name: String,
+    val price: Int,
+    val status: ProductStatus
+) {
+
+    companion object {
+        fun from(productHistory: ProductHistory): ProductHistoryResponse {
+            return ProductHistoryResponse(
+                productHistory.createdAudit.createdAt,
+                productHistory.createdAudit.createdBy,
+                productHistory.name,
+                productHistory.price,
+                productHistory.status
+            )
+        }
+    }
+}

--- a/product-api/src/test/kotlin/com/example/productapi/product/api/ProductControllerTest.kt
+++ b/product-api/src/test/kotlin/com/example/productapi/product/api/ProductControllerTest.kt
@@ -1,5 +1,6 @@
 package com.example.productapi.product.api
 
+import com.example.productapi.product.api.controller.ProductController
 import com.example.productapi.product.api.request.ProductCreateRequest
 import com.example.productapi.product.api.request.ProductEditRequest
 import com.example.productapi.product.api.request.ProductRequest

--- a/product-api/src/test/kotlin/com/example/productapi/product/api/controller/ProductHistoryControllerTest.kt
+++ b/product-api/src/test/kotlin/com/example/productapi/product/api/controller/ProductHistoryControllerTest.kt
@@ -1,0 +1,84 @@
+package com.example.productapi.product.api.controller
+
+import com.example.productdomain.common.CreatedAudit
+import com.example.productdomain.common.UpdatedAudit
+import com.example.productdomain.product.application.ProductHistoryQueryService
+import com.example.productdomain.product.domain.*
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.restdocs.RestDocumentationExtension
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get
+import org.springframework.restdocs.operation.preprocess.Preprocessors
+import org.springframework.restdocs.payload.PayloadDocumentation
+import org.springframework.restdocs.request.RequestDocumentation
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import java.time.LocalDateTime
+
+@ExtendWith(value = [RestDocumentationExtension::class])
+@AutoConfigureRestDocs(uriHost = "api.test.com", uriPort = 8080)
+@WebMvcTest(controllers = [ProductHistoryController::class])
+class ProductHistoryControllerTest @Autowired constructor(
+
+    @Autowired
+    val mockMvc: MockMvc,
+
+    @MockkBean
+    val productHistoryQueryService: ProductHistoryQueryService
+) {
+
+    @Test
+    @DisplayName("[GET] [/v1/products/{productId}/histories] 상품 히스토리 조회 API")
+    fun getProductHistories() {
+        val now = LocalDateTime.of(2024, 3, 9, 0, 0)
+        val product = Product(
+            CreatedAudit(now, "0000"),
+            UpdatedAudit(now, "0000"),
+            ProductName("test"),
+            ProductPrice(1000),
+            ProductQuantity(10),
+            ProductStatus.PRE_REGISTRATION,
+            1L
+        )
+
+        every { productHistoryQueryService.getProductHistories(product.id!!) }
+            .returns(listOf(ProductHistory.from(product)))
+
+        mockMvc.perform(get("/v1/products/{productId}/histories", product.id))
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.handler().methodName("getProductHistories"))
+            .andExpect(jsonPath("$[0].name").value("test"))
+            .andExpect(jsonPath("$[0].price").value("1000"))
+            .andExpect(jsonPath("$[0].status").value("PRE_REGISTRATION"))
+            .andExpect(jsonPath("$[0].createdBy").value("0000"))
+            .andExpect(jsonPath("$[0].createdAt").value("2024-03-09T00:00:00"))
+            .andDo(
+                MockMvcRestDocumentation.document(
+                    "product/product-histories",
+                    Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                    Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                    RequestDocumentation.pathParameters(
+                        RequestDocumentation.parameterWithName("productId").description("상품 ID")
+                    ),
+                    PayloadDocumentation.responseFields(
+                        PayloadDocumentation.fieldWithPath("[].name").description("상품 이름"),
+                        PayloadDocumentation.fieldWithPath("[].price").description("상품 가격"),
+                        PayloadDocumentation.fieldWithPath("[].status").description("상품 상태"),
+                        PayloadDocumentation.fieldWithPath("[].createdAt").description("수정 일자"),
+                        PayloadDocumentation.fieldWithPath("[].createdBy").description("수정자")
+                    )
+                )
+            )
+
+    }
+
+}

--- a/product-domain/src/main/kotlin/com/example/productdomain/product/application/ProductCommandService.kt
+++ b/product-domain/src/main/kotlin/com/example/productdomain/product/application/ProductCommandService.kt
@@ -4,6 +4,8 @@ import com.example.productdomain.common.UpdatedAudit
 import com.example.productdomain.product.application.dto.ProductCreateInput
 import com.example.productdomain.product.application.dto.ProductEditInput
 import com.example.productdomain.product.domain.Product
+import com.example.productdomain.product.domain.ProductHistory
+import com.example.productdomain.product.domain.ProductHistoryRepository
 import com.example.productdomain.product.domain.ProductRepository
 import com.example.productdomain.util.findByIdOrThrow
 import lombok.extern.slf4j.Slf4j
@@ -14,11 +16,13 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 @Transactional
 class ProductCommandService(
-    val productRepository: ProductRepository
+    val productRepository: ProductRepository,
+    val productHistoryRepository: ProductHistoryRepository
 ) {
 
     fun create(input: ProductCreateInput): Product {
         val product = productRepository.save(input.toProduct())
+        productHistoryRepository.save(ProductHistory.from(product))
 
         return product;
     }
@@ -26,20 +30,17 @@ class ProductCommandService(
     fun edit(productId: Long, input: ProductEditInput, updatedAudit: UpdatedAudit): Product {
         val product: Product = productRepository.findByIdOrThrow(productId)
 
-        return product.apply {
-            update(
-                updatedAudit,
-                input.name,
-                input.price,
-                input.quantity,
-                input.status
-            )
-        }
+        product.update(updatedAudit, input.name, input.price, input.quantity, input.status)
+
+        productHistoryRepository.save(ProductHistory.from(product))
+        return product
     }
 
     fun delete(productId: Long, updatedAudit: UpdatedAudit) {
         val product: Product = productRepository.findByIdOrThrow(productId)
 
         product.delete(updatedAudit);
+
+        productHistoryRepository.save(ProductHistory.from(product))
     }
 }

--- a/product-domain/src/main/kotlin/com/example/productdomain/product/application/ProductHistoryQueryService.kt
+++ b/product-domain/src/main/kotlin/com/example/productdomain/product/application/ProductHistoryQueryService.kt
@@ -1,0 +1,20 @@
+package com.example.productdomain.product.application
+
+import com.example.productdomain.product.domain.ProductHistory
+import com.example.productdomain.product.domain.ProductHistoryRepository
+import lombok.extern.slf4j.Slf4j
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+class ProductHistoryQueryService(
+    val productHistoryRepository: ProductHistoryRepository
+) {
+
+    fun getProductHistories(productId: Long): List<ProductHistory> {
+
+        return productHistoryRepository.findByProductId(productId)
+    }
+}

--- a/product-domain/src/main/kotlin/com/example/productdomain/product/domain/Product.kt
+++ b/product-domain/src/main/kotlin/com/example/productdomain/product/domain/Product.kt
@@ -34,7 +34,7 @@ class Product(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "product_id")
-    val id: Long? = null,
+    val id: Long? = null
 ) {
 
     fun update(

--- a/product-domain/src/main/kotlin/com/example/productdomain/product/domain/ProductHistory.kt
+++ b/product-domain/src/main/kotlin/com/example/productdomain/product/domain/ProductHistory.kt
@@ -1,0 +1,42 @@
+package com.example.productdomain.product.domain
+
+import com.example.productdomain.common.CreatedAudit
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "product_histories")
+class ProductHistory(
+
+    @Embedded
+    val createdAudit: CreatedAudit,
+
+    val name: String,
+
+    val price: Int,
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "status")
+    val status: ProductStatus,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    val product: Product,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "product_history_id")
+    val id: Long? = null
+) {
+
+    companion object {
+        fun from(product: Product): ProductHistory {
+            return ProductHistory(
+                CreatedAudit(product.updatedAudit.updatedAt, product.updatedAudit.updatedBy),
+                product.name.value,
+                product.price.value,
+                product.status,
+                product
+            )
+        }
+    }
+}

--- a/product-domain/src/main/kotlin/com/example/productdomain/product/domain/ProductHistory.kt
+++ b/product-domain/src/main/kotlin/com/example/productdomain/product/domain/ProductHistory.kt
@@ -18,9 +18,8 @@ class ProductHistory(
     @Column(name = "status")
     val status: ProductStatus,
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "product_id")
-    val product: Product,
+    @Column(name = "product_id")
+    val productId: Long,
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -35,7 +34,7 @@ class ProductHistory(
                 product.name.value,
                 product.price.value,
                 product.status,
-                product
+                product.id!!
             )
         }
     }

--- a/product-domain/src/main/kotlin/com/example/productdomain/product/domain/ProductHistoryRepository.kt
+++ b/product-domain/src/main/kotlin/com/example/productdomain/product/domain/ProductHistoryRepository.kt
@@ -1,0 +1,7 @@
+package com.example.productdomain.product.domain
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ProductHistoryRepository : JpaRepository<ProductHistory, Long> {
+    fun findByProduct(product: Product): ProductHistory
+}

--- a/product-domain/src/main/kotlin/com/example/productdomain/product/domain/ProductHistoryRepository.kt
+++ b/product-domain/src/main/kotlin/com/example/productdomain/product/domain/ProductHistoryRepository.kt
@@ -3,5 +3,5 @@ package com.example.productdomain.product.domain
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface ProductHistoryRepository : JpaRepository<ProductHistory, Long> {
-    fun findByProduct(product: Product): ProductHistory
+    fun findByProductId(productId: Long): List<ProductHistory>
 }

--- a/product-domain/src/main/resources/db/migration/V20240316162943__create_productHistory.sql
+++ b/product-domain/src/main/resources/db/migration/V20240316162943__create_productHistory.sql
@@ -1,0 +1,9 @@
+CREATE TABLE product_histories (
+    product_history_id BIGINT AUTO_INCREMENT NOT NULL PRIMARY KEY ,
+    product_id BIGINT NOT NULL ,
+    name VARCHAR(51) NOT NULL,
+    price INT NOT NULL,
+    status VARCHAR(51) NOT NULL,
+    created_by VARCHAR(51),
+    created_at DATETIME
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/product-domain/src/test/kotlin/com/example/productdomain/config/SpringBootTester.kt
+++ b/product-domain/src/test/kotlin/com/example/productdomain/config/SpringBootTester.kt
@@ -1,6 +1,7 @@
 package com.example.productdomain.config
 
 import com.example.productdomain.ProductDomainConfig
+import com.example.productdomain.product.domain.ProductHistoryRepository
 import com.example.productdomain.product.domain.ProductRepository
 import org.junit.jupiter.api.AfterEach
 import org.springframework.beans.factory.annotation.Autowired
@@ -13,9 +14,13 @@ class SpringBootTester {
     @Autowired
     lateinit var productRepository: ProductRepository
 
+    @Autowired
+    lateinit var productHistoryRepository: ProductHistoryRepository
+
 
     @AfterEach
     fun tearDown() {
         productRepository.deleteAll()
+        productHistoryRepository.deleteAll()
     }
 }

--- a/product-domain/src/test/kotlin/com/example/productdomain/product/ProducFixture.kt
+++ b/product-domain/src/test/kotlin/com/example/productdomain/product/ProducFixture.kt
@@ -2,10 +2,7 @@ package com.example.productdomain.product
 
 import com.example.productdomain.common.CreatedAudit
 import com.example.productdomain.common.UpdatedAudit
-import com.example.productdomain.product.domain.Product
-import com.example.productdomain.product.domain.ProductName
-import com.example.productdomain.product.domain.ProductPrice
-import com.example.productdomain.product.domain.ProductQuantity
+import com.example.productdomain.product.domain.*
 import java.time.LocalDateTime
 
 fun createDefaultProduct(): Product {
@@ -17,6 +14,8 @@ fun createDefaultProduct(): Product {
         UpdatedAudit(now, memberNumber),
         ProductName("test"),
         ProductPrice(1000),
-        ProductQuantity(100)
+        ProductQuantity(100),
+        ProductStatus.PRE_REGISTRATION,
+        0L
     )
 }

--- a/product-domain/src/test/kotlin/com/example/productdomain/product/application/ProductCommandServiceTest.kt
+++ b/product-domain/src/test/kotlin/com/example/productdomain/product/application/ProductCommandServiceTest.kt
@@ -33,6 +33,26 @@ class ProductCommandServiceTest @Autowired constructor(
     }
 
     @Test
+    @DisplayName("상품 기본 정보로 상품을 생성시 히스토리도 생성한다.")
+    fun createHistory() {
+        val now = LocalDateTime.of(2024, 3, 6, 0, 0)
+        val input = ProductCreateInput("test", 1000, 10, CreatedAudit(now, "0000"), UpdatedAudit(now, "0000"))
+
+        val product = productCommandService.create(input)
+
+        val history = productHistoryRepository.findByProduct(product)
+        assertThat(history.id).isNotNull()
+        assertThat(history)
+            .extracting(
+                ProductHistory::name,
+                ProductHistory::price,
+                ProductHistory::status,
+                ProductHistory::createdAudit
+            )
+            .contains("test", 1000, ProductStatus.PRE_REGISTRATION, CreatedAudit(now, "0000"));
+    }
+
+    @Test
     @DisplayName("상품 정보를 수정한다.")
     fun edit() {
         val beforeProduct = productRepository.save(createDefaultProduct())
@@ -52,6 +72,35 @@ class ProductCommandServiceTest @Autowired constructor(
     }
 
     @Test
+    @DisplayName("상품 수정시 히스토리도 생성한다.")
+    fun editHistory() {
+        val beforeProduct = productRepository.save(createDefaultProduct())
+        val input = ProductEditInput("test2", 100, 10000, ProductStatus.SELLING)
+
+        val afterProduct = productCommandService.edit(
+            beforeProduct.id!!,
+            input,
+            UpdatedAudit(LocalDateTime.of(2023, 12, 31, 0, 0), "root")
+        );
+
+        val history = productHistoryRepository.findByProduct(afterProduct)
+        assertThat(history.id).isNotNull()
+        assertThat(history)
+            .extracting(
+                ProductHistory::name,
+                ProductHistory::price,
+                ProductHistory::status,
+                ProductHistory::createdAudit
+            )
+            .contains(
+                "test2",
+                100,
+                ProductStatus.SELLING,
+                CreatedAudit(LocalDateTime.of(2023, 12, 31, 0, 0), "root")
+            )
+    }
+
+    @Test
     @DisplayName("상품 ID 에 해당하는 상품을 삭제한다.")
     fun delete() {
         val product = createDefaultProduct()
@@ -62,5 +111,26 @@ class ProductCommandServiceTest @Autowired constructor(
         val deletedProduct = productRepository.findByIdOrThrow(persistProduct.id)
         assertThat(productRepository.count()).isEqualTo(1)
         assertThat(deletedProduct.status).isEqualTo(ProductStatus.DELETED)
+    }
+
+    @Test
+    @DisplayName("상품 ID 에 해당하는 상품을 삭제한다.")
+    fun deleteHistory() {
+        val product = createDefaultProduct()
+        val persistProduct = productRepository.save(product)
+
+        productCommandService.delete(persistProduct.id!!, UpdatedAudit(LocalDateTime.of(2023, 12, 31, 0, 0), "root"))
+
+        val history = productHistoryRepository.findByProduct(product)
+        assertThat(history.id).isNotNull()
+        assertThat(history)
+            .extracting(
+                ProductHistory::status,
+                ProductHistory::createdAudit
+            )
+            .contains(
+                ProductStatus.DELETED,
+                CreatedAudit(LocalDateTime.of(2023, 12, 31, 0, 0), "root")
+            )
     }
 }

--- a/product-domain/src/test/kotlin/com/example/productdomain/product/application/ProductCommandServiceTest.kt
+++ b/product-domain/src/test/kotlin/com/example/productdomain/product/application/ProductCommandServiceTest.kt
@@ -40,7 +40,7 @@ class ProductCommandServiceTest @Autowired constructor(
 
         val product = productCommandService.create(input)
 
-        val history = productHistoryRepository.findByProduct(product)
+        val history = productHistoryRepository.findByProductId(product.id!!)[0]
         assertThat(history.id).isNotNull()
         assertThat(history)
             .extracting(
@@ -83,7 +83,7 @@ class ProductCommandServiceTest @Autowired constructor(
             UpdatedAudit(LocalDateTime.of(2023, 12, 31, 0, 0), "root")
         );
 
-        val history = productHistoryRepository.findByProduct(afterProduct)
+        val history = productHistoryRepository.findByProductId(afterProduct.id!!)[0]
         assertThat(history.id).isNotNull()
         assertThat(history)
             .extracting(
@@ -121,7 +121,7 @@ class ProductCommandServiceTest @Autowired constructor(
 
         productCommandService.delete(persistProduct.id!!, UpdatedAudit(LocalDateTime.of(2023, 12, 31, 0, 0), "root"))
 
-        val history = productHistoryRepository.findByProduct(product)
+        val history = productHistoryRepository.findByProductId(product.id!!)[0]
         assertThat(history.id).isNotNull()
         assertThat(history)
             .extracting(

--- a/product-domain/src/test/kotlin/com/example/productdomain/product/application/ProductHistoryQueryServiceTest.kt
+++ b/product-domain/src/test/kotlin/com/example/productdomain/product/application/ProductHistoryQueryServiceTest.kt
@@ -1,0 +1,40 @@
+package com.example.productdomain.product.application
+
+import com.example.productdomain.common.CreatedAudit
+import com.example.productdomain.common.UpdatedAudit
+import com.example.productdomain.config.SpringBootTester
+import com.example.productdomain.product.application.dto.ProductCreateInput
+import com.example.productdomain.product.application.dto.ProductEditInput
+import com.example.productdomain.product.domain.ProductStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDateTime
+
+class ProductHistoryQueryServiceTest @Autowired constructor(
+    val productCommandService: ProductCommandService,
+    val productHistoryQueryService: ProductHistoryQueryService
+) : SpringBootTester() {
+
+    @Test
+    @DisplayName("상품의 이력을 조회한다.")
+    fun getProductHistories() {
+        val now = LocalDateTime.of(2024, 2, 16, 0, 0)
+        val createInput = ProductCreateInput(
+            "test1",
+            100,
+            10,
+            CreatedAudit(now, "0000"),
+            UpdatedAudit(now, "0000")
+        )
+        val editInput = ProductEditInput("test2", 1000, 100, ProductStatus.SELLING)
+        val product = productCommandService.create(createInput)
+        productCommandService.edit(product.id!!, editInput, UpdatedAudit(now.plusDays(1), "0000"))
+        productCommandService.delete(product.id!!, UpdatedAudit(now.plusDays(2), "0000"))
+
+        val productHistories = productHistoryQueryService.getProductHistories(product.id!!)
+
+        assertThat(productHistories).hasSize(3)
+    }
+}

--- a/product-domain/src/test/kotlin/com/example/productdomain/product/domain/ProductHistoryTest.kt
+++ b/product-domain/src/test/kotlin/com/example/productdomain/product/domain/ProductHistoryTest.kt
@@ -1,0 +1,95 @@
+package com.example.productdomain.product.domain
+
+import com.example.productdomain.common.CreatedAudit
+import com.example.productdomain.common.UpdatedAudit
+import com.example.productdomain.product.createDefaultProduct
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class ProductHistoryTest {
+
+    @Test
+    @DisplayName("상품 생성시 생성에 대한 히스토리를 생성한다.")
+    fun createAtHistory() {
+        val product = createDefaultProduct()
+
+        val productHistory = ProductHistory.from(product)
+
+        assertThat(productHistory)
+            .extracting(
+                ProductHistory::createdAudit,
+                ProductHistory::name,
+                ProductHistory::price,
+                ProductHistory::status,
+                ProductHistory::product
+            )
+            .contains(
+                CreatedAudit(product.updatedAudit.updatedAt, product.updatedAudit.updatedBy),
+                product.name.value,
+                product.price.value,
+                product.status,
+                product
+            )
+    }
+
+    @Test
+    @DisplayName("상품 수정시 생성에 대한 히스토리를 생성한다.")
+    fun updateAtHistory() {
+        val product = createDefaultProduct()
+        product.update(
+            UpdatedAudit(LocalDateTime.of(2024, 3, 16, 0, 0), "root"),
+            "new",
+            1000000,
+            1000000,
+            ProductStatus.SELLING
+        )
+
+        val productHistory = ProductHistory.from(product)
+
+        assertThat(productHistory)
+            .extracting(
+                ProductHistory::createdAudit,
+                ProductHistory::name,
+                ProductHistory::price,
+                ProductHistory::status,
+                ProductHistory::product
+            )
+            .contains(
+                CreatedAudit(LocalDateTime.of(2024, 3, 16, 0, 0), "root"),
+                "new",
+                1000000,
+                1000000,
+                ProductStatus.SELLING,
+                product
+            )
+    }
+
+    @Test
+    @DisplayName("상품 삭제시 생성에 대한 히스토리를 생성한다.")
+    fun deleteAtHistory() {
+        val product = createDefaultProduct()
+        product.delete(UpdatedAudit(LocalDateTime.of(2024, 3, 15, 0, 0), "root"))
+
+        val productHistory = ProductHistory.from(product)
+
+        assertThat(productHistory)
+            .extracting(
+                ProductHistory::createdAudit,
+                ProductHistory::name,
+                ProductHistory::price,
+                ProductHistory::status,
+                ProductHistory::product
+            )
+            .contains(
+                CreatedAudit(LocalDateTime.of(2024, 3, 15, 0, 0), "root"),
+                "test",
+                1000,
+                ProductStatus.DELETED,
+                product
+            )
+    }
+}
+
+

--- a/product-domain/src/test/kotlin/com/example/productdomain/product/domain/ProductHistoryTest.kt
+++ b/product-domain/src/test/kotlin/com/example/productdomain/product/domain/ProductHistoryTest.kt
@@ -23,14 +23,14 @@ class ProductHistoryTest {
                 ProductHistory::name,
                 ProductHistory::price,
                 ProductHistory::status,
-                ProductHistory::product
+                ProductHistory::productId
             )
             .contains(
                 CreatedAudit(product.updatedAudit.updatedAt, product.updatedAudit.updatedBy),
                 product.name.value,
                 product.price.value,
                 product.status,
-                product
+                product.id
             )
     }
 
@@ -54,7 +54,7 @@ class ProductHistoryTest {
                 ProductHistory::name,
                 ProductHistory::price,
                 ProductHistory::status,
-                ProductHistory::product
+                ProductHistory::productId
             )
             .contains(
                 CreatedAudit(LocalDateTime.of(2024, 3, 16, 0, 0), "root"),
@@ -62,7 +62,7 @@ class ProductHistoryTest {
                 1000000,
                 1000000,
                 ProductStatus.SELLING,
-                product
+                product.id
             )
     }
 
@@ -80,14 +80,14 @@ class ProductHistoryTest {
                 ProductHistory::name,
                 ProductHistory::price,
                 ProductHistory::status,
-                ProductHistory::product
+                ProductHistory::productId
             )
             .contains(
                 CreatedAudit(LocalDateTime.of(2024, 3, 15, 0, 0), "root"),
                 "test",
                 1000,
                 ProductStatus.DELETED,
-                product
+                product.id
             )
     }
 }


### PR DESCRIPTION
## 작업 종류

- [X] 기능 추가
- [ ] 리팩토링
- [ ] 기타

## 작업 내용
- 상품의 상태가 변경되었을 때 ProductHistory 를 만들어서 append 한다.
- 상품 히스토리를 조회할 수 있는 API 개발


## 참고 사항
